### PR TITLE
Fixed script termination when an API fork compare returns '404 Not Found'

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -282,10 +282,12 @@ async function fetchMoreDir(repo, originalBranch, fork, fromOriginal, api) {
   });
   const data = await api.fetch(url, limiter);
 
-  if (fromOriginal)
-    fork.diff_from_original = printInfo('-', data, fork);
-  else
-    fork.diff_to_original = printInfo('+', data, fork);
+  if (data !== null) {
+    if (fromOriginal)
+      fork.diff_from_original = printInfo('-', data, fork);
+    else
+      fork.diff_to_original = printInfo('+', data, fork);
+  }
 }
 
 function printInfo(sep, data, fork) {
@@ -368,6 +370,8 @@ function Api(token) {
       const response = await fetch(url, newConfig);
       if (response.status === 304)
         return cached.data;
+      if (response.status === 404)
+        return null;
       if (!response.ok)
         throw Error(response.statusText);
 


### PR DESCRIPTION
(e.g. user does not exist any longer)